### PR TITLE
Rename credential config files to be more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The tool is on the very early state and can be executed with local hardcoded cre
 2. Build the project
 3. Create three files with credential configs (`airbyte_creds.json`, `destination_creds.json`, `source_creds.json`) in the folder `secrets`.
 
-     ![image](https://user-images.githubusercontent.com/30464745/185108683-8aeb3adb-5a5d-4560-8ed4-8ea6bbf2fb28.png)
+     ![image](https://user-images.githubusercontent.com/1310940/185700802-b6a75916-efdf-4b22-bafb-19fc23f0c9d7.png)
 
 4. Run `TestingTool::main`
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ The tool is on the very early state and can be executed with local hardcoded cre
 
 1. Clone the repository
 2. Build the project
-3. Create three files with credential configs (`airbyte_local_creds.json`, `postgres_test_dest_creds.json`, `postgres_test_source_creds.json`) in the folder `secrets`.
+3. Create three files with credential configs (`airbyte_creds.json`, `destination_creds.json`, `source_creds.json`) in the folder `secrets`.
 
      ![image](https://user-images.githubusercontent.com/30464745/185108683-8aeb3adb-5a5d-4560-8ed4-8ea6bbf2fb28.png)
 
-4. Run `TestingTool.main`
+4. Run `TestingTool::main`
 
 
 ## CHANGELOG

--- a/src/main/java/io/airbyte/testingtool/scenario/ScenarioFactory.java
+++ b/src/main/java/io/airbyte/testingtool/scenario/ScenarioFactory.java
@@ -30,8 +30,8 @@ public class ScenarioFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ScenarioFactory.class);
 
-  public static TestScenario getScenario(ScenarioConfig config, List<CredentialConfig> credentialConfigs) {
-    Map<String, Instance> scenarioInstanceNameToInstanceMap = mapInstancesAndCredentials(config, credentialConfigs);
+  public static TestScenario getScenario(final ScenarioConfig config, final List<CredentialConfig> credentialConfigs) {
+    final Map<String, Instance> scenarioInstanceNameToInstanceMap = mapInstancesAndCredentials(config, credentialConfigs);
 
     return TestScenario.builder()
         .scenarioName(config.getScenarioName())
@@ -40,27 +40,27 @@ public class ScenarioFactory {
         .build();
   }
 
-  private static Map<String, Instance> mapInstancesAndCredentials(ScenarioConfig config, List<CredentialConfig> credentialConfigs) {
-    Map<String, Instance> resultMap = new HashMap<>();
+  private static Map<String, Instance> mapInstancesAndCredentials(final ScenarioConfig config, final List<CredentialConfig> credentialConfigs) {
+    final Map<String, Instance> resultMap = new HashMap<>();
 
-    Set<ScenarioConfigInstance> allInstances = getScenarioInstances(config);
+    final Set<ScenarioConfigInstance> allInstances = getScenarioInstances(config);
     allInstances.forEach(scenarioConfigInstance -> {
-      var instance = InstanceFactory.getInstance(scenarioConfigInstance, getCorrespondingConfigAndRemove(scenarioConfigInstance, credentialConfigs));
+      final var instance = InstanceFactory.getInstance(scenarioConfigInstance, getCorrespondingConfigAndRemove(scenarioConfigInstance, credentialConfigs));
       resultMap.put(instance.getInstanceName(), instance);
     });
 
     return resultMap;
   }
 
-  private static Set<ScenarioConfigInstance> getScenarioInstances(ScenarioConfig config) {
+  private static Set<ScenarioConfigInstance> getScenarioInstances(final ScenarioConfig config) {
     if (!ValidationService.validateScenarioConfig(config)) {
       throw new RuntimeException("Scenario validation failed! Check the log for more details.");
     }
     return new HashSet<>(config.getUsedInstances());
   }
 
-  private static CredentialConfig getCorrespondingConfigAndRemove(ScenarioConfigInstance instanceConfig, List<CredentialConfig> credentialConfigs) {
-    var cred = credentialConfigs.stream()
+  private static CredentialConfig getCorrespondingConfigAndRemove(final ScenarioConfigInstance instanceConfig, final List<CredentialConfig> credentialConfigs) {
+    final var cred = credentialConfigs.stream()
         .filter(credentialConfig -> credentialConfig.getCredentialType().equals(instanceConfig.getInstanceType().getRequiredCredentials()))
         .findFirst().orElse(null);
     if (cred != null) {
@@ -70,23 +70,23 @@ public class ScenarioFactory {
     return cred;
   }
 
-  public static TestScenario getScenario(String[] args) throws IOException {
+  public static TestScenario getScenario(final String[] args) throws IOException {
     return getScenario(ScenarioConfigService.getConfig(args), getCreds(args));
   }
 
-  private static SortedSet<ScenarioAction> getActions(List<ScenarioConfigAction> actionConfigs,
-      Map<String, Instance> scenarioInstanceNameToInstanceMap) {
-    SortedSet<ScenarioAction> actions = new TreeSet<>();
+  private static SortedSet<ScenarioAction> getActions(final List<ScenarioConfigAction> actionConfigs,
+      final Map<String, Instance> scenarioInstanceNameToInstanceMap) {
+    final SortedSet<ScenarioAction> actions = new TreeSet<>();
     actionConfigs.forEach(scenarioConfigAction ->
         actions.add(ActionFactory.getScenarioAction(actions.size(), scenarioConfigAction, scenarioInstanceNameToInstanceMap))
     );
     return actions;
   }
 
-  private static List<CredentialConfig> getCreds(String[] args) throws IOException {
-    final String airbyte = Files.readString(Path.of("secrets/airbyte_local_creds.json"));
-    final String source = Files.readString(Path.of("secrets/postgres_test_source_creds.json"));
-    final String dest = Files.readString(Path.of("secrets/postgres_test_dest_creds.json"));
+  private static List<CredentialConfig> getCreds(final String[] args) throws IOException {
+    final String airbyte = Files.readString(Path.of("secrets/airbyte_creds.json"));
+    final String source = Files.readString(Path.of("secrets/source_creds.json"));
+    final String dest = Files.readString(Path.of("secrets/destination_creds.json"));
 
     return new ArrayList<>(
         Arrays.asList(Jsons.deserialize(source, CredentialConfig.class), Jsons.deserialize(dest, CredentialConfig.class),


### PR DESCRIPTION
- The code allows creating any type of source and destination, so having "postgres" as a prefix in credential files is confusing
- The tool can work with a remove Airbyte instance as well as with local, so having "local" as part of airbyte instance credential file name is also confusing