### PR TITLE
Fixed error in intellijIdea build right after project import

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ plugins {
     id 'jsonschema2pojo'
 }
 
+sourceCompatibility = 17
+targetCompatibility = 17
+
 version '0.1.0'
 
 repositories {


### PR DESCRIPTION
Fixed the issue on the initial project's import to intelliIdea.

Currently, the project's build failed right after import until you do not set java version explicitly in IntelliIdea's config. 
This PR should fix it.

![Selection_439](https://user-images.githubusercontent.com/4688354/185973415-0b2d7eaa-0e62-449f-97b4-842779974920.png)

